### PR TITLE
Update goals_page.dart

### DIFF
--- a/lib/goals_page.dart
+++ b/lib/goals_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:fplproject/coolors.dart';
-import 'package:fplproject/widgets/goal_card.dart';
+import 'coolors.dart';
+import 'widgets/goal_card.dart';
 import 'package:velocity_x/velocity_x.dart';
 
 class GoalsPage extends StatelessWidget {


### PR DESCRIPTION
after cloning of the code we users have to remove the default project name